### PR TITLE
Add travis with Sauce support config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+node_js: stable
+dist: trusty
+sudo: required
+addons:
+  firefox: '46.0'
+  apt:
+    sources:
+    - google-chrome
+    packages:
+    - google-chrome-stable
+before_script:
+- npm install -g bower polylint web-component-tester
+- bower install
+- polylint
+script:
+- xvfb-run wct

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: trusty
 sudo: required
 addons:
   firefox: '46.0'
+  sauce_connect: true
   apt:
     sources:
     - google-chrome

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,0 +1,25 @@
+{
+  "plugins": {
+    "local": {
+      "browsers": ["chrome", "firefox"]
+    },
+    "sauce": {
+      "disabled": false,
+      "browsers": [{
+          "browserName": "microsoftedge",
+          "platform": "Windows 10",
+          "version": ""
+        }, {
+          "browserName": "internet explorer",
+          "platform": "Windows 8.1",
+          "version": "11"
+        },
+        {
+          "browserName": "safari",
+          "platform": "OS X 10.11",
+          "version": "9"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR just adds the automated tests travis-ci config file if you want to use, just follow their instructions here: https://docs.travis-ci.com/user/getting-started/

To integrate with sauce, follow this: https://docs.travis-ci.com/user/sauce-connect/
